### PR TITLE
Optimize wheel redraw

### DIFF
--- a/src/main/java/org/example/Roue.java
+++ b/src/main/java/org/example/Roue.java
@@ -57,6 +57,9 @@ public class Roue {
     private String[] seatNames;
     private Color[]  seatColors;
 
+    // Dernier hash de la liste de malus pour éviter les reconstructions inutiles
+    private int malusHash = 0;
+
     private SVGPath  spear;
     private ParallelTransition winFx;
     private Consumer<String>   spinCallback;
@@ -103,6 +106,11 @@ public class Roue {
     /* 6)  Construction                                             */
     /* ============================================================ */
     public void updateWheelDisplay(ObservableList<String> malus){
+        int newHash = malus.hashCode();
+        if (newHash == malusHash) {
+            return; // aucune modification de la liste
+        }
+        malusHash = newHash;
         buildSeatArrays(malus);
 
         wheelGroup.setRotate(0);
@@ -124,7 +132,9 @@ public class Roue {
     /* 7)  Spin (2 signatures)                                      */
     /* ============================================================ */
     public void spinTheWheel(ObservableList<String> malus){
-        updateWheelDisplay(malus);
+        if (malus.hashCode() != malusHash) {
+            updateWheelDisplay(malus);
+        }
         spinTheWheel();
     }
     public void spinTheWheel(){


### PR DESCRIPTION
## Summary
- cache malus list hash inside `Roue`
- skip wheel reconstruction when list hasn't changed
- only refresh wheel on spin when needed

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687be91d9f84832e92c375e6544749d2