### PR TITLE
Correctifs divers sur la roue et la gestion des participants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
                 <version>${javafx.maven.plugin.version}</version>
                 <configuration>
                     <mainClass>org.example.Launcher</mainClass>
-                    <jvmArgs>-Dprism.msaaSamples=4</jvmArgs>
                 </configuration>
             </plugin>
 

--- a/src/main/java/org/example/Gains.java
+++ b/src/main/java/org/example/Gains.java
@@ -45,14 +45,22 @@ public class Gains {
 
         // ► Binding qui formate la cagnotte avec des espaces tous les 3 chiffres
         lblTotal.textProperty().bind(
-                Bindings.createStringBinding(() -> {
-                    int total = participants.stream().mapToInt(Participant::getLevel).sum()
-                            + extraKamas.get();
-                    // Mise en forme : ",d" produit "23,000,000" → on remplace ',' par ' '
-                    String formatted = String.format("%,d", total).replace(',', ' ');
-                    return "Cagnotte : " + formatted + " 𝚔";
-                }, participants, extraKamas)
+                Bindings.createStringBinding(() ->
+                                String.format("Cagnotte : %,d 𝚔",
+                                        participants.stream().mapToInt(Participant::getLevel).sum()
+                                                + extraKamas.get()).replace(',', ' '),
+                        participants, extraKamas
+                )
         );
+
+        participants.addListener((ListChangeListener<Participant>) c -> {
+            while (c.next()) {
+                if (c.wasAdded()) {
+                    c.getAddedSubList().forEach(p ->
+                            p.levelProperty().addListener((o, ov, nv) -> lblTotal.requestLayout()));
+                }
+            }
+        });
 
         // Bouton : ajoute le montant du champ à la cagnote
         Button btnAddKamas = new Button("Ajouter");

--- a/src/main/java/org/example/Historique.java
+++ b/src/main/java/org/example/Historique.java
@@ -23,13 +23,11 @@ public class Historique extends Stage {
 
     private final ObservableList<String> lignes = FXCollections.observableArrayList();
     private final ListView<String> listView;
-    private final Gains gains;
     private static final Path FILE = Path.of("loterie-historique.txt");
     private static final DateTimeFormatter FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
-    public Historique(Gains gains) {
-        this.gains = gains;
+    public Historique() {
         setTitle("Historique des tirages");
 
         listView = new ListView<>(lignes);

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -27,8 +27,6 @@ public class Main extends Application {
     // Rayon de la roue
     public static final double WHEEL_RADIUS  = 320;
 
-    // Durée du spin
-    public static final double SPIN_DURATION = 5.0; // en secondes
 
     @Override
     public void start(Stage primaryStage) {
@@ -58,7 +56,7 @@ public class Main extends Application {
 
         // Instancie la fenêtre des gains pour l'historique
         Gains gains = new Gains(users.getParticipants());
-        Historique historique = new Historique(gains);
+        Historique historique = new Historique();
 
         VBox leftBox = new VBox(10, users.getRootPane());
         // On supprime le padding-top

--- a/src/main/java/org/example/Participant.java
+++ b/src/main/java/org/example/Participant.java
@@ -1,44 +1,26 @@
 package org.example;
 
-/**
- * Simple classe de données décrivant un participant :
- * - Pseudo (name)
- * - Classe du personnage
- * - Niveau (level)
- */
+import javafx.beans.property.*;
+
 public class Participant {
-    private String name;
-    private int level;         // Niveau du joueur
-    private String classe;     // Classe du personnage
 
-    public Participant(String name, int level, String classe) {
-        this.name = name;
-        this.level = level;
-        this.classe = classe;
+    private final StringProperty  name   = new SimpleStringProperty();
+    private final IntegerProperty level  = new SimpleIntegerProperty();
+    private final StringProperty  classe = new SimpleStringProperty();
+
+    public Participant(String n, int l, String c) {
+        name.set(n); level.set(l); classe.set(c);
     }
 
-    /* ============== Getters et Setters ============== */
-    public String getName() {
-        return name;
-    }
+    public String getName()   { return name.get(); }
+    public int    getLevel()  { return level.get(); }
+    public String getClasse() { return classe.get(); }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+    public void setName(String v){ name.set(v); }
+    public void setLevel(int v){  level.set(v); }
+    public void setClasse(String v){ classe.set(v); }
 
-    public int getLevel() {
-        return level;
-    }
-
-    public void setLevel(int level) {
-        this.level = level;
-    }
-
-    public String getClasse() {
-        return classe;
-    }
-
-    public void setClasse(String classe) {
-        this.classe = classe;
-    }
+    public StringProperty  nameProperty()   { return name; }
+    public IntegerProperty levelProperty()  { return level; }
+    public StringProperty  classeProperty() { return classe; }
 }

--- a/src/main/java/org/example/Roue.java
+++ b/src/main/java/org/example/Roue.java
@@ -63,6 +63,7 @@ public class Roue {
     private SVGPath  spear;
     private ParallelTransition winFx;
     private Consumer<String>   spinCallback;
+    private List<String> lastMalus = List.of();
 
     // drag
     private double dragX, dragY;
@@ -82,7 +83,7 @@ public class Roue {
         wheelGroup.setCacheHint(CacheHint.ROTATE);
         root.getChildren().add(wheelGroup);
 
-        SVGPath spear = new SVGPath();
+        spear = new SVGPath();
         spear.setContent("M0,-" + (Main.WHEEL_RADIUS + 18) + " L-8,-" +
                 (Main.WHEEL_RADIUS - 4) + " L0,-" + (Main.WHEEL_RADIUS - 14) +
                 " L8,-" + (Main.WHEEL_RADIUS - 4) + " Z");
@@ -90,7 +91,6 @@ public class Roue {
         spear.setStroke(Color.BLACK);
         spear.setStrokeWidth(1.2);
         root.getChildren().add(spear);
-        this.spear = spear;
 
         enableDrag();
     }
@@ -106,6 +106,12 @@ public class Roue {
     /* 6)  Construction                                             */
     /* ============================================================ */
     public void updateWheelDisplay(ObservableList<String> malus){
+        if (malus.isEmpty()) {
+            wheelGroup.getChildren().clear();
+            arcs.clear();
+            seatNames = new String[0];
+            return;
+        }
         int newHash = malus.hashCode();
         if (newHash == malusHash) {
             return; // aucune modification de la liste
@@ -129,15 +135,16 @@ public class Roue {
     }
 
     /* ============================================================ */
-    /* 7)  Spin (2 signatures)                                      */
+    /* 7)  Spin                                                     */
     /* ============================================================ */
     public void spinTheWheel(ObservableList<String> malus){
-        if (malus.hashCode() != malusHash) {
+        if (!malus.equals(lastMalus)) {
             updateWheelDisplay(malus);
+            lastMalus = List.copyOf(malus);
         }
-        spinTheWheel();
+        spin();
     }
-    public void spinTheWheel(){
+    private void spin(){
 
         if (winFx != null) { winFx.stop(); clearHighlight(); }
 
@@ -151,18 +158,19 @@ public class Roue {
         double target = idx * sector + sector / 2 - 90;
         double totalTurns = 6;                           // à ajuster
         double finalAngle = totalTurns * 360 + target;
+        double dur = OptionRoue.getSpinDuration();
 
         DoubleProperty angle = wheelGroup.rotateProperty();
 
         // 1) Accélération (0 → 720 ° en 10 % du temps, ease-in)
         KeyFrame kfStart = new KeyFrame(
-                Duration.seconds(OptionRoue.getSpinDuration() * .10),
+                Duration.seconds(dur * .10),
                 new KeyValue(angle, 720, Interpolator.SPLINE(0.42, 0.0, 1.0, 1.0))
         );
 
         // 2) Décélération (720 ° → finalAngle en 90 % du temps, ease-out)
         KeyFrame kfStop = new KeyFrame(
-                Duration.seconds(OptionRoue.getSpinDuration()),
+                Duration.seconds(dur),
                 new KeyValue(angle, finalAngle, Interpolator.SPLINE(0.0, 0.0, 0.58, 1.0))
         );
 

--- a/src/main/java/org/example/Theme.java
+++ b/src/main/java/org/example/Theme.java
@@ -173,4 +173,11 @@ public class Theme {
         ));
         label.setEffect(new DropShadow(10, Color.rgb(0, 0, 0, 0.35)));
     }
+
+    /** Affiche une boîte d'erreur simple. */
+    public static void showError(String msg) {
+        Alert a = new Alert(Alert.AlertType.ERROR, msg, ButtonType.OK);
+        a.setHeaderText(null);
+        a.showAndWait();
+    }
 }

--- a/src/main/java/org/example/Users.java
+++ b/src/main/java/org/example/Users.java
@@ -30,9 +30,9 @@ public class Users {
         TableColumn<Participant,Integer> colLevel = new TableColumn<>("Level");
         TableColumn<Participant,String>  colClasse= new TableColumn<>("Classe");
 
-        colNom   .setCellValueFactory(p -> new SimpleStringProperty (p.getValue().getName()));
-        colLevel .setCellValueFactory(p -> new SimpleIntegerProperty(p.getValue().getLevel()).asObject());
-        colClasse.setCellValueFactory(p -> new SimpleStringProperty (p.getValue().getClasse()));
+        colNom   .setCellValueFactory(p -> p.getValue().nameProperty());
+        colLevel .setCellValueFactory(p -> p.getValue().levelProperty().asObject());
+        colClasse.setCellValueFactory(p -> p.getValue().classeProperty());
 
         /* === Cellule colorée par INDEX de ligne ======================= */
         colNom.setCellFactory(column -> new TableCell<>() {
@@ -79,11 +79,18 @@ public class Users {
 
         add.setOnAction(e -> {
             String n = tNom.getText().trim();
-            if(!n.isEmpty()){
-                int lv = tLevel.getText().isBlank()?0:Integer.parseInt(tLevel.getText());
-                participants.add(new Participant(n,lv,tClasse.getText().trim()));
-                tNom.clear(); tLevel.clear(); tClasse.clear();
+            if (n.isEmpty()) return;
+
+            int lv;
+            try {
+                lv = Integer.parseInt(tLevel.getText().trim());
+            } catch (NumberFormatException ex) {
+                Theme.showError("Le level doit être un nombre entier.");
+                return;
             }
+
+            participants.add(new Participant(n, lv, tClasse.getText().trim()));
+            tNom.clear(); tLevel.clear(); tClasse.clear();
         });
         del.setOnAction(e -> {
             Participant sel = table.getSelectionModel().getSelectedItem();


### PR DESCRIPTION
## Summary
- évite la division par zéro lors de la mise à jour de la roue
- mémorise la liste de malus pour éviter les reconstructions
- protège la saisie du niveau et affiche une alerte en cas d’erreur
- convertit `Participant` en classe à propriétés JavaFX
- met à jour le calcul dynamique de la cagnotte
- simplifie `Historique` et retire l’anti‑aliasing MSAA
- uniformise la durée du spin

## Testing
- `mvn -q -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687c25ad1554832e81412b2fafb971e8