### PR TITLE
Fix RouletteBonus constructor name

### DIFF
--- a/src/main/java/org/example/bonus/RouletteBonus.java
+++ b/src/main/java/org/example/bonus/RouletteBonus.java
@@ -84,7 +84,7 @@ public class RouletteBonus {
     /* ============================================================ */
     /* 4)  Constructeur                                             */
     /* ============================================================ */
-    public Roue(Resultat res){
+    public RouletteBonus(Resultat res){
         this.resultat = res;
 
         root = new StackPane();


### PR DESCRIPTION
## Summary
- rename constructor of `RouletteBonus` from `Roue` to `RouletteBonus`

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_687d4fe36604832e80dfc0e61cadece7