### PR TITLE
Add individual bonus roulette and persistence

### DIFF
--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -12,6 +12,9 @@ import javafx.scene.layout.*;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
+import org.example.bonus.Bonus;
+import org.example.bonus.BonusDialog;
+
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -57,6 +60,13 @@ public class Main extends Application {
         // Instancie la fenêtre des gains pour l'historique
         Gains gains = new Gains(users.getParticipants());
         Historique historique = new Historique();
+
+        // liste partagée de tous les bonus disponibles
+        ObservableList<Bonus> bonusMasterList = FXCollections.observableArrayList(
+                new Bonus("Puissance +100"),
+                new Bonus("Dommages ×1,2"),
+                new Bonus("Initiative +500")
+        );
 
         VBox leftBox = new VBox(10, users.getRootPane());
         // On supprime le padding-top
@@ -110,15 +120,16 @@ public class Main extends Application {
                     if (line.startsWith("#")) {
                         continue;
                     }
-                    String[] parts = line.split(";", 3);
-                    if (parts.length == 3) {
-                        users.getParticipants().add(
-                                new Participant(
-                                        parts[0],
-                                        Integer.parseInt(parts[1]),
-                                        parts[2]
-                                )
-                        );
+                    String[] parts = line.split(";", -1);     // -1 : garde le champ vide
+                    if (parts.length >= 3) {
+                        Participant p = new Participant(parts[0],
+                                Integer.parseInt(parts[1]),
+                                parts[2]);
+                        if (parts.length == 4 && !parts[3].isBlank()) {
+                            for (String b : parts[3].split("\\|"))
+                                p.addBonus(new Bonus(b));
+                        }
+                        users.getParticipants().add(p);
                     }
                 }
             }
@@ -171,6 +182,14 @@ public class Main extends Application {
             resultat.setMessage("Nouvelle loterie prête");
         });
 
+        Button indivButton = new Button("Roulette individuelle");
+        Theme.styleButton(indivButton);
+        indivButton.setOnAction(e ->
+                new BonusDialog(bonusMasterList,
+                                users.getParticipants(),
+                                historique)
+                        .show());
+
         // === Nouveau bouton "Plein écran" ===
         Button fullScreenButton = new Button("Plein écran");
         fullScreenButton.setOnAction(e -> {
@@ -189,12 +208,13 @@ public class Main extends Application {
         Theme.styleButton(resetButton);
         Theme.styleButton(saveButton);
         Theme.styleButton(cleanButton);
+        Theme.styleButton(indivButton);
         Theme.styleButton(fullScreenButton);
         Theme.styleButton(historyButton);
 
         HBox bottomBox = new HBox(30,
                 spinButton, optionsButton, resetButton,
-                saveButton, cleanButton,
+                saveButton, cleanButton, indivButton,
                 fullScreenButton, historyButton
         );
         bottomBox.setAlignment(Pos.CENTER);

--- a/src/main/java/org/example/bonus/BonusDialog.java
+++ b/src/main/java/org/example/bonus/BonusDialog.java
@@ -1,13 +1,16 @@
 package org.example.bonus;
 
 import javafx.collections.ObservableList;
+import javafx.collections.FXCollections;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ListView;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
@@ -40,6 +43,26 @@ public class BonusDialog extends Stage {
             wheel.spinTheWheel(bonusList, p);
         });
 
+        // 1) list view des bonus du joueur
+        ListView<Bonus> playerBonus = new ListView<>();
+        Theme.styleListView(playerBonus);
+        playerBonus.setPrefHeight(260);
+
+        // 2) bouton pour retirer le bonus sélectionné
+        Button remove = new Button("Retirer");
+        Theme.styleButton(remove);
+        remove.setOnAction(ev -> {
+            Bonus b = playerBonus.getSelectionModel().getSelectedItem();
+            Participant p = combo.getSelectionModel().getSelectedItem();
+            if (b!=null && p!=null) p.removeBonus(b);
+        });
+
+        // 3) chaque fois qu’on change de joueur -> montre ses bonus
+        combo.getSelectionModel().selectedItemProperty().addListener((obs, oldP, newP) -> {
+            playerBonus.setItems(newP==null? FXCollections.emptyObservableList()
+                                            : newP.getBonusList());
+        });
+
         wheel.setOnBonusWon((p,b) -> {
             p.addBonus(new Bonus(b));
             historique.logBonus(p,b);
@@ -52,6 +75,12 @@ public class BonusDialog extends Stage {
         BorderPane root = new BorderPane();
         root.setLeft(pane.getRootPane());
         root.setCenter(wheel.getRootPane());
+
+        VBox right = new VBox(10, playerBonus, remove);
+        right.setAlignment(Pos.TOP_CENTER);
+        right.setPadding(new Insets(10));
+
+        root.setRight(right);
         root.setTop(result.getNode());
         BorderPane.setAlignment(result.getNode(), Pos.CENTER);
         root.setBottom(bottom);


### PR DESCRIPTION
## Summary
- add shared bonus list and new button to open an individual bonus dialog
- show player's bonuses in `BonusDialog` with ability to remove them
- load saved bonuses from `loterie-save.txt`

## Testing
- `mvn -q --no-transfer-progress javafx:run` *(fails: No plugin found)*
- `mvn -q --no-transfer-progress test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d53c1a67c832e862e944d34f8c35c