### PR TITLE
Implement wheel rebuild caching

### DIFF
--- a/src/main/java/org/example/Roue.java
+++ b/src/main/java/org/example/Roue.java
@@ -126,6 +126,9 @@ public class Roue {
             return;
         }
         int newHash = malus.hashCode();
+        if (newHash == malusHash && seatNames != null) {
+            return;
+        }
         malusHash = newHash;
         buildSeatArrays(malus);
 

--- a/src/main/java/org/example/bonus/RouletteBonus.java
+++ b/src/main/java/org/example/bonus/RouletteBonus.java
@@ -132,6 +132,9 @@ public class RouletteBonus {
             return;
         }
         int newHash = bonus.hashCode();
+        if (newHash == bonusHash && seatNames != null) {
+            return;
+        }
         bonusHash = newHash;
         buildSeatArrays(bonus);
 

--- a/src/main/java/org/example/wheel/BaseWheel.java
+++ b/src/main/java/org/example/wheel/BaseWheel.java
@@ -92,6 +92,9 @@ public abstract class BaseWheel<T> {
             return;
         }
         int newHash = items.hashCode();
+        if (newHash == listHash && seatNames.length > 0) {
+            return;
+        }
         listHash = newHash;
         buildSeatArrays(items);
 

--- a/src/test/java/org/example/RoueTest.java
+++ b/src/test/java/org/example/RoueTest.java
@@ -38,4 +38,22 @@ public class RoueTest {
         List<?> arcs = (List<?>) arcsField.get(roue);
         assertEquals(3, arcs.size());
     }
+
+    @Test
+    public void testWheelUpdateSkipsWhenUnchanged() throws Exception {
+        Resultat resultat = new Resultat();
+        MalusWheel roue = new MalusWheel(resultat);
+        ObservableList<String> malus = FXCollections.observableArrayList("A", "B");
+
+        roue.updateWheelDisplay(malus);
+
+        Field seatNamesField = BaseWheel.class.getDeclaredField("seatNames");
+        seatNamesField.setAccessible(true);
+        Object before = seatNamesField.get(roue);
+
+        roue.updateWheelDisplay(malus);
+        Object after = seatNamesField.get(roue);
+
+        assertSame(before, after);
+    }
 }


### PR DESCRIPTION
## Summary
- skip wheel rebuild when list hash hasn't changed
- add test ensuring rebuild is skipped when inputs match

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687e7eca9ae0832eb048703dc347b4a1