### PR TITLE
Add background image for BonusDialog

### DIFF
--- a/src/main/java/org/example/bonus/BonusDialog.java
+++ b/src/main/java/org/example/bonus/BonusDialog.java
@@ -74,6 +74,7 @@ public class BonusDialog extends Stage {
         bottom.setPadding(new Insets(10));
 
         BorderPane root = new BorderPane();
+        root.setBackground(Theme.makeBackgroundCover("/img_2.png"));
         root.setLeft(pane.getRootPane());
         root.setCenter(wheel.getRootPane());
 


### PR DESCRIPTION
## Summary
- remove unnecessary img_2.png asset
- apply `/img_2.png` background to `BonusDialog`

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687e8d9a29a4832eb5edd3902c796531